### PR TITLE
Add ls-trace to recommendationservice

### DIFF
--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -5,6 +5,9 @@ RUN apt-get update -qqy && \
 # show python logs as they occur
 ENV PYTHONUNBUFFERED=0
 
+ENV DD_TRACE_AGENT_URL=https://ingest.lightstep.com:443
+ENV DD_TRACE_GLOBAL_TAGS="lightstep.service_name:recommendationservices,lightstep.access_token:Wfhecs+qnaOncJb5L8PHCuo98pnddVhtayxCtQ0lV7vZuzz7EptplEe/yTeO5E4ZBGBSg3oOcstlbeZ/nlZ2lc8lNd3z3/+35ZoXGeZQ"
+
 # download the grpc health probe
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.0 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
@@ -14,6 +17,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.2.0 && \
 WORKDIR /recommendationservice
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
+RUN pip install ls-trace
 
 # add files into working directory
 COPY . .
@@ -22,4 +26,4 @@ COPY . .
 ENV PORT "8080"
 EXPOSE 8080
 
-ENTRYPOINT ["python", "/recommendationservice/recommendation_server.py"]
+ENTRYPOINT ["ls-trace-run", "python", "/recommendationservice/recommendation_server.py"]

--- a/src/recommendationservice/client.py
+++ b/src/recommendationservice/client.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ddtrace import tracer
+from ddtrace.propagation.b3 import B3HTTPPropagator
+tracer.configure(http_propagator=B3HTTPPropagator)
+
 import sys
 import grpc
 import demo_pb2


### PR DESCRIPTION
## Summary

**WARNING**: This intentionally includes the access token in the Dockerfile for simplicity. This will need to revisited before making this repo public.

Adds the `ls-trace` auto-installer to the `recommendationservice` `Dockerfile`.

