### PR TITLE
Add ls-trace to emailservice

### DIFF
--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -10,12 +10,16 @@ RUN apt-get -qq update \
 # get packages
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+RUN pip install ls-trace
 
 FROM base as final
 # Enable unbuffered logging
 ENV PYTHONUNBUFFERED=1
 # Enable Profiler
 ENV ENABLE_PROFILER=1
+
+ENV DD_TRACE_AGENT_URL=https://ingest.lightstep.com:443
+ENV DD_TRACE_GLOBAL_TAGS="lightstep.service_name:emailservice,lightstep.access_token:Wfhecs+qnaOncJb5L8PHCuo98pnddVhtayxCtQ0lV7vZuzz7EptplEe/yTeO5E4ZBGBSg3oOcstlbeZ/nlZ2lc8lNd3z3/+35ZoXGeZQ"
 
 RUN apt-get -qq update \
     && apt-get install -y --no-install-recommends \
@@ -35,4 +39,4 @@ COPY --from=builder /usr/local/lib/python3.7/ /usr/local/lib/python3.7/
 COPY . .
 
 EXPOSE 8080
-ENTRYPOINT [ "python", "email_server.py" ]
+ENTRYPOINT [ "ls-trace-run", "python", "email_server.py" ]

--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ddtrace import tracer
+from ddtrace.propagation.b3 import B3HTTPPropagator
+tracer.configure(http_propagator=B3HTTPPropagator)
+
 from concurrent import futures
 import argparse
 import os


### PR DESCRIPTION
## Summary

**WARNING**: This intentionally includes the access token in the Dockerfile for simplicity. This will need to revisited before making this repo public.

Adds the `ls-trace` auto-installer to the `emailservice` `Dockerfile`.

