### PR TITLE
Initial adservice support.

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -36,6 +36,11 @@ spec:
           value: "9555"
         #- name: JAEGER_SERVICE_ADDR
         #  value: "jaeger-collector:14268"
+        - name: SECRET_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ls-access-token
+              key: token
         resources:
           requests:
             cpu: 200m

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -56,7 +56,11 @@ dependencies {
                 "io.grpc:grpc-stub:${grpcVersion}",
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
-                "org.apache.logging.log4j:log4j-core:2.11.1"
+                "org.apache.logging.log4j:log4j-core:2.11.1",
+                "com.lightstep.opencensus:lightstep-opencensus-exporter:0.0.3",
+                "com.lightstep.tracer:lightstep-tracer-jre:0.18.4",
+                "com.lightstep.tracer:tracer-okhttp:0.19.3",
+                "org.slf4j:slf4j-simple:1.7.25"
 
         runtime "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",

--- a/src/adservice/src/main/java/hipstershop/AdServiceClient.java
+++ b/src/adservice/src/main/java/hipstershop/AdServiceClient.java
@@ -136,6 +136,9 @@ public class AdServiceClient {
     long sleepTime = 10; /* seconds */
     int maxAttempts = 3;
 
+    /*
+     * Disable Stackdriver for now.
+     *
     for (int i = 0; i < maxAttempts; i++) {
       try {
         StackdriverTraceExporter.createAndRegister(StackdriverTraceConfiguration.builder().build());
@@ -159,7 +162,7 @@ public class AdServiceClient {
           }
         }
       }
-    }
+    }*/
 
     // Register Prometheus exporters and export metrics to a Prometheus HTTPServer.
     // PrometheusStatsCollector.createAndRegister();


### PR DESCRIPTION
Initial, primitive tracing support.

* No propagation (as the OC's gRPC implementation does nothing for the tracing part, and also the B3 support is experimental :/ )
* Uses our LS' OC exporter.
* Disables StackDriver initialization, as that was crashing the app.

Spans are parentless at this point.