### PR TITLE
loadgenerator: pin python to 3.7 instead of 3.x

### DIFF
--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim as base
+FROM python:3.7-slim as base
 
 FROM base as builder
 


### PR DESCRIPTION
3.8 has a problem with the pinned werkzeug version. Instead of messing
with pip requirements, just downgrade Python.

Issue: https://github.com/pallets/werkzeug/issues/1551

+ STATUSCODE=200
+ test 200 -ne 200
+ locust --host=http://frontend:80 --no-web -c 500
Traceback (most recent call last):
  File "/usr/local/bin/locust", line 11, in <module>
    load_entry_point('locustio==0.8.1', 'console_scripts', 'locust')()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 490, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2854, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2445, in load
    return self.resolve()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2451, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.8/site-packages/locust/main.py", line 14, in <module>
    from . import events, runners, web
  File "/usr/local/lib/python3.8/site-packages/locust/web.py", line 27, in <module>
    app = Flask(__name__)
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 558, in __init__
    self.add_url_rule(
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 66, in wrapper_func
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1216, in add_url_rule
    self.url_map.add(rule)
  File "/usr/local/lib/python3.8/site-packages/werkzeug/routing.py", line 1386, in add
    rule.bind(self)
  File "/usr/local/lib/python3.8/site-packages/werkzeug/routing.py", line 730, in bind
    self.compile()
  File "/usr/local/lib/python3.8/site-packages/werkzeug/routing.py", line 794, in compile
    self._build = self._compile_builder(False).__get__(self, None)
  File "/usr/local/lib/python3.8/site-packages/werkzeug/routing.py", line 945, in _compile_builder
    code = compile(module, "<werkzeug routing>", "exec")
TypeError: required field "type_ignores" missing from Module