### PR TITLE
Fix regression in credentials setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -46,16 +46,6 @@ wait_for_store () {
     printf '.'
     sleep 5
   done
-  # while true; do
-  #   echo -n "."
-  #   curl -s -q http://localhost > /dev/null
-  #   rc=$?
-  #   if [ $rc == 0 ]; then
-  #     echo "done!"
-  #     return
-  #   fi
-  #   sleep 1
-  # done
 }
 
 # Called if the user is deploying to GKE. Ensures the necessary environment
@@ -74,6 +64,7 @@ gke_steps () {
     exit
   fi
 
+  set_ls_credentials
   make run
 }
 


### PR DESCRIPTION
Fixes a regression where the Lightstep credentials secret was not longer being set for the GKE deployment. The missing secret was causing a "silent" failure on the CLI side that would not be intuitive to the end user.

Also removes some commented out code.