### PR TITLE
Refactor manifests to use Lightstep configmap object

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -12,72 +12,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: adservice
-spec:
-  selector:
-    matchLabels:
-      app: adservice
-  template:
-    metadata:
-      labels:
-        app: adservice
-    spec:
-      terminationGracePeriodSeconds: 5
-      containers:
-      - name: server
-        image: adservice
-        ports:
-        - containerPort: 9555
-        env:
-        - name: PORT
-          value: "9555"
-        # - name: LIGHTSTEP_SERVICE_NAME
-        #   value: "adservice-test"
-        - name: LIGHTSTEP_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: lightstep-credentials
-              key: accessToken
-        - name: LIGHTSTEP_COLLECTOR_HOST
-          value: "satellite"
-        - name: LIGHTSTEP_COLLECTOR_PORT
-          value: "8181"
-        - name: LIGHTSTEP_COLLECTOR_PROTOCOL
-          value: "http"
-        - name: JAEGER_SERVICE_ADDR
-          value: "lightstep-satellite:8181"
-        resources:
-          requests:
-            cpu: 200m
-            memory: 180Mi
-          limits:
-            cpu: 300m
-            memory: 300Mi
-        readinessProbe:
-          initialDelaySeconds: 20
-          periodSeconds: 15
-          timeoutSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:9555", "-connect-timeout=5s", "-rpc-timeout=5s"]
-        livenessProbe:
-          initialDelaySeconds: 20
-          periodSeconds: 15
-          timeoutSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:9555", "-connect-timeout=5s", "-rpc-timeout=5s"]
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: adservice
-spec:
-  type: ClusterIP
-  selector:
-    app: adservice
-  ports:
-  - name: grpc
-    port: 9555
-    targetPort: 9555
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#   name: adservice
+# spec:
+#   selector:
+#     matchLabels:
+#       app: adservice
+#   template:
+#     metadata:
+#       labels:
+#         app: adservice
+#     spec:
+#       terminationGracePeriodSeconds: 5
+#       containers:
+#       - name: server
+#         image: adservice
+#         ports:
+#         - containerPort: 9555
+#         env:
+#         - name: PORT
+#           value: "9555"
+#         # - name: LIGHTSTEP_SERVICE_NAME
+#         #   value: "adservice-test"
+#         - name: LIGHTSTEP_ACCESS_TOKEN
+#           valueFrom:
+#             secretKeyRef:
+#               name: lightstep-credentials
+#               key: accessToken
+#         - name: LIGHTSTEP_COLLECTOR_HOST
+#           value: "satellite"
+#         - name: LIGHTSTEP_COLLECTOR_PORT
+#           value: "8181"
+#         - name: LIGHTSTEP_COLLECTOR_PROTOCOL
+#           value: "http"
+#         - name: JAEGER_SERVICE_ADDR
+#           value: "lightstep-satellite:8181"
+#         resources:
+#           requests:
+#             cpu: 200m
+#             memory: 180Mi
+#           limits:
+#             cpu: 300m
+#             memory: 300Mi
+#         readinessProbe:
+#           initialDelaySeconds: 20
+#           periodSeconds: 15
+#           timeoutSeconds: 5
+#           exec:
+#             command: ["/bin/grpc_health_probe", "-addr=:9555", "-connect-timeout=5s", "-rpc-timeout=5s"]
+#         livenessProbe:
+#           initialDelaySeconds: 20
+#           periodSeconds: 15
+#           timeoutSeconds: 5
+#           exec:
+#             command: ["/bin/grpc_health_probe", "-addr=:9555", "-connect-timeout=5s", "-rpc-timeout=5s"]
+# ---
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: adservice
+# spec:
+#   type: ClusterIP
+#   selector:
+#     app: adservice
+#   ports:
+#   - name: grpc
+#     port: 9555
+#     targetPort: 9555

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -31,6 +31,9 @@ spec:
         image: cartservice
         ports:
         - containerPort: 7070
+        envFrom:
+        - configMapRef:
+            name: lightstep-configmap
         env:
         - name: REDIS_ADDR
           value: "redis-cart:6379"
@@ -44,12 +47,6 @@ spec:
             secretKeyRef:
               name: lightstep-credentials
               key: accessToken
-        - name: LIGHTSTEP_HOST
-          value: "ingest.lightstep.com"
-        - name: LIGHTSTEP_PORT
-          value: "443"
-        - name: LIGHTSTEP_PLAINTEXT
-          value: "false"
         - name: HIPSTER_SICK # Used for GCP demo
           value: "false"
         resources:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -38,6 +38,9 @@ spec:
             timeoutSeconds: 30
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:5050", "-rpc-timeout=30s"]
+          envFrom:
+          - configMapRef:
+              name: lightstep-configmap
           env:
           - name: PORT
             value: "5050"
@@ -54,12 +57,6 @@ spec:
           - name: CART_SERVICE_ADDR
             value: "cartservice:7070"
           # Lightstep config
-          - name: LIGHTSTEP_HOST
-            value: "ingest.lightstep.com"
-          - name: LIGHTSTEP_PORT
-            value: "443"
-          - name: LIGHTSTEP_PLAINTEXT
-            value: "false"
           - name: LIGHTSTEP_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -32,16 +32,13 @@ spec:
         ports:
         - name: grpc
           containerPort: 7000
+        envFrom:
+        - configMapRef:
+            name: lightstep-configmap
         env:
         - name: PORT
           value: "7000"
         # Lightstep config
-        - name: LIGHTSTEP_HOST
-          value: "ingest.lightstep.com"
-        - name: LIGHTSTEP_PORT
-          value: "443"
-        - name: LIGHTSTEP_PLAINTEXT
-          value: "false"
         - name: LIGHTSTEP_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -31,17 +31,14 @@ spec:
         image: emailservice
         ports:
         - containerPort: 8080
+        envFrom:
+          - configMapRef:
+              name: lightstep-configmap
         env:
         - name: PORT
           value: "8080"
         - name: ENABLE_PROFILER
           value: "0"
-        - name: LIGHTSTEP_HOST
-          value: "ingest.lightstep.com"
-        - name: LIGHTSTEP_PORT
-          value: "443"
-        - name: LIGHTSTEP_PLAINTEXT
-          value: "false"
         - name: LIGHTSTEP_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -50,6 +50,9 @@ spec:
               httpHeaders:
               - name: "Cookie"
                 value: "shop_session-id=x-liveness-probe"
+          envFrom:
+          - configMapRef:
+              name: lightstep-configmap
           env:
           - name: PORT
             value: "8080"
@@ -67,12 +70,6 @@ spec:
             value: "checkoutservice:5050"
           - name: AD_SERVICE_ADDR
             value: "adservice:9555"
-          - name: LIGHTSTEP_HOST
-            value: "ingest.lightstep.com"
-          - name: LIGHTSTEP_PORT
-            value: "443"
-          - name: LIGHTSTEP_PLAINTEXT
-            value: "false"
           - name: LIGHTSTEP_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/kubernetes-manifests/lightstep-configmap.yaml
+++ b/kubernetes-manifests/lightstep-configmap.yaml
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: lightstep-configmap
+data:
+  LIGHTSTEP_HOST: "ingest.lightstep.com"
+  LIGHTSTEP_PORT: "443"
+  LIGHTSTEP_PLAINTEXT: "false"

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -31,16 +31,13 @@ spec:
         image: paymentservice
         ports:
         - containerPort: 50051
+        envFrom:
+        - configMapRef:
+            name: lightstep-configmap
         env:
         - name: PORT
           value: "50051"
         # Lightstep config
-        - name: LIGHTSTEP_HOST
-          value: "ingest.lightstep.com"
-        - name: LIGHTSTEP_PORT
-          value: "443"
-        - name: LIGHTSTEP_PLAINTEXT
-          value: "false"
         - name: LIGHTSTEP_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -31,15 +31,12 @@ spec:
         image: productcatalogservice
         ports:
         - containerPort: 3550
+        envFrom:
+        - configMapRef:
+            name: lightstep-configmap
         env:
         - name: PORT
           value: "3550"
-        - name: LIGHTSTEP_HOST
-          value: "ingest.lightstep.com"
-        - name: LIGHTSTEP_PORT
-          value: "443"
-        - name: LIGHTSTEP_PLAINTEXT
-          value: "false"
         - name: LIGHTSTEP_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -41,6 +41,9 @@ spec:
           timeoutSeconds: 5
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:8080", "-connect-timeout=5s", "-rpc-timeout=5s"]
+        envFrom:
+        - configMapRef:
+            name: lightstep-configmap
         env:
         - name: PORT
           value: "8080"
@@ -48,12 +51,6 @@ spec:
           value: "productcatalogservice:3550"
         - name: ENABLE_PROFILER
           value: "0"
-        - name: LIGHTSTEP_HOST
-          value: "ingest.lightstep.com"
-        - name: LIGHTSTEP_PORT
-          value: "443"
-        - name: LIGHTSTEP_PLAINTEXT 
-          value: "false"
         - name: LIGHTSTEP_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -30,15 +30,12 @@ spec:
           image: shippingservice
           ports:
             - containerPort: 50051
+          envFrom:
+          - configMapRef:
+              name: lightstep-configmap
           env:
             - name: PORT
               value: "50051"
-            - name: LIGHTSTEP_HOST
-              value: "ingest.lightstep.com"
-            - name: LIGHTSTEP_PORT
-              value: "443"
-            - name: LIGHTSTEP_PLAINTEXT
-              value: "false"
             - name: LIGHTSTEP_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Extracts `LIGHTSTEP_HOST`, `LIGHTSTEP_PORT`, and `LIGHTSTEP_PLAINTEXT` to config map to be shared between all services.

Also comments out the `adservice` manifest, which cannot deploy to k8s currently.

This allows easy overrides to point to local satellites, etc.