### PR TITLE
Update python services' Dockerfiles

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -5,7 +5,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    py3-pip \
+    python3 \
     make \
     g++ \
     git

--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -5,7 +5,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    py3-pip \
     make \
     g++ \
     git

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -5,7 +5,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    py3-pip \
+    python3 \
     make \
     g++ \
     git

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -5,7 +5,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    py3-pip \
     make \
     g++ \
     git


### PR DESCRIPTION
`skaffold run` was failing for me on building the python services on "python" not being found. I found this lucky comment in a related issue when using a different version of node alpine [here](https://stackoverflow.com/questions/54428608/docker-node-alpine-image-build-fails-on-node-gyp#comment119857409_59538284). Upon updating to `py3-pip` everything worked as expected.